### PR TITLE
fix docker hub link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Transformers on GPU AMD Radeon in Docker
-Basic configuration of the docker container [hardandheavy/transformers-rocm](https://hub.docker.com/repository/docker/hardandheavy/transformers-rocm/general) for working with [transformer models](https://huggingface.co) on GPU from Radeon.
+Basic configuration of the docker container [hardandheavy/transformers-rocm](https://hub.docker.com/r/hardandheavy/transformers-rocm) for working with [transformer models](https://huggingface.co) on GPU from Radeon.
 
 ### Requirements
 * Ubuntu


### PR DESCRIPTION
the provided docker link takes me to a sign-in page - replaced it with the public docker hub repository URL